### PR TITLE
Keyboard nav

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -66,8 +66,8 @@
 
 	<!-- Main Body -->
 	<div id="app_main">
-		<app-map> </app-map>
 		<app-home tabindex="1"></app-home>
+		<app-map> </app-map>
 	</div>
 
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -67,12 +67,12 @@
 	<!-- Main Body -->
 	<div id="app_main">
 		<app-map> </app-map>
-		<app-home></app-home>
+		<app-home tabindex="1"></app-home>
 	</div>
 
 
 	<!-- USGS Footer -->
-	<footer id="usgs">
+	<footer id="usgs" tabindex="0">
 		<div>
 			<a href="https://www.doi.gov/privacy">DOI Privacy Policy</a>
 			<a href="https://www.usgs.gov/laws/policies_notices.html">Legal</a>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -4,13 +4,10 @@
 	justify-content: center;
 	height: 100%;
 }
-
 #app_main{
 	flex-grow: 3;
 	position: relative;
 }
-
-
 
 // USGS Header
 #usgsBar{
@@ -33,9 +30,6 @@ footer#usgs{
 		position: relative;
 		text-decoration: none;
 	}
-
-
-
 
 
 	// USA Banner

--- a/src/app/core/about/about.component.html
+++ b/src/app/core/about/about.component.html
@@ -2,19 +2,19 @@
   aria-label="This panel contains information about CyAN">
   <div class="aboutModal">
     <div class="flex-container">
-      <div matTooltip="FAQ" class="aboutBtn" (click)=" aboutView('faqView')" id="faqViewID">
-        <mat-icon class="aboutText flex-child aboutIcon">question_answer</mat-icon>
-      </div>
-      <div matTooltip="User's Guide" class="aboutBtn" (click)="aboutView('userGuideView')" id="userGuideViewID">
-        <mat-icon class="aboutText flex-child aboutIcon">library_books</mat-icon>
-      </div>
-      <div matTooltip="Accessibility Tips" class="aboutBtn" (click)="aboutView('accessibilityView')"
+      <button matTooltip="FAQ" class="aboutBtn" (click)=" aboutView('faqView')" id="faqViewID">
+        <mat-icon class="flex-child aboutIcon">question_answer</mat-icon>
+      </button>
+      <button matTooltip="User's Guide" class="aboutBtn" (click)="aboutView('userGuideView')" id="userGuideViewID">
+        <mat-icon class="flex-child aboutIcon">library_books</mat-icon>
+      </button>
+      <button matTooltip="Accessibility Tips" class="aboutBtn" (click)="aboutView('accessibilityView')"
         id="accessibilityViewID">
-        <mat-icon class="aboutText flex-child aboutIcon">accessibility_new</mat-icon>
-      </div>
-      <div matTooltip="Disclaimer" class="aboutBtn " (click)="aboutView('disclaimerView')" id="disclaimerViewID">
-        <mat-icon class="aboutText flex-child aboutIcon">warning</mat-icon>
-      </div>
+        <mat-icon class="flex-child aboutIcon">accessibility_new</mat-icon>
+      </button>
+      <button matTooltip="Disclaimer" class="aboutBtn " (click)="aboutView('disclaimerView')" id="disclaimerViewID">
+        <mat-icon class="flex-child aboutIcon">warning</mat-icon>
+      </button>
     </div>
     <div class="infoContent marginTopFullHeight" id="infoContentID">
       <div [hidden]="!userGuide">
@@ -471,18 +471,18 @@
           types, download the <i>Flag Types</i> table. For help interpreting the columns in your downloaded results,
           download the <i>Results</i> table.
           <div class="flex-container">
-            <div class="mapFilterBtn dataBtn" (click)="pcodeDownload()">
+            <button class="mapFilterBtn dataBtn" (click)="pcodeDownload()">
               Parameters
-            </div>
-            <div class="mapFilterBtn dataBtn leftBreak" (click)="mcodeDownload()">
+            </button>
+            <button class="mapFilterBtn dataBtn leftBreak" (click)="mcodeDownload()">
               Methods
-            </div>
-            <div class="mapFilterBtn dataBtn leftBreak" (click)="flagTypesDownload()">
+            </button>
+            <button class="mapFilterBtn dataBtn leftBreak" (click)="flagTypesDownload()">
               Flag Types
-            </div>
-            <div class="mapFilterBtn dataBtn leftBreak" (click)="resultsKeyDownload()">
+            </button>
+            <button class="mapFilterBtn dataBtn leftBreak" (click)="resultsKeyDownload()">
               Results
-            </div>
+            </button>
           </div>
         </ol>
       </div>
@@ -616,12 +616,12 @@
           <i>annotation</i> column is for you to type custom notes; there is no required format for this.
         </div>
         <div class="flex-container">
-          <div class="flagTemplateBtn dataBtn" (click)="flagTemplateDownload()" matTooltip="{{flagTemplateTooltip()}}">
+          <button class="flagTemplateBtn dataBtn" (click)="flagTemplateDownload()" matTooltip="{{flagTemplateTooltip()}}">
             Flag Template
-          </div>
-          <div class="mapFilterBtn dataBtn leftBreak" (click)="flagTypesDownload()" matTooltip="{{flagTypesTooltip()}}">
+		  </button>
+          <button class="mapFilterBtn dataBtn leftBreak" (click)="flagTypesDownload()" matTooltip="{{flagTypesTooltip()}}">
             Flag Types
-          </div>
+		  </button>
         </div>
       </div>
     </div>

--- a/src/app/core/home/home.component.html
+++ b/src/app/core/home/home.component.html
@@ -4,43 +4,42 @@
       <div [hidden]="!showFullCyanHomeBtn"
         aria-label="This is a yellow button featuring a house icon. Clicking on it will take you to the CyAN landing page.">
         <div class="flex-child" [hidden]="!showFullCyanHomeBtn">
-          <div id="homeBtnFullID" class="landingPgBtns homeBtn homeBtnColor marginLeftFullWidth" (click)="clickHome()"
+          <button id="homeBtnFullID" class="landingPgBtns homeBtn homeBtnColor marginLeftFullWidth wm-focus" (click)="clickHome()"
             [hidden]="!showFullCyanHomeBtn" matTooltip="Home">
-            <mat-icon class="homeFullScreenIcon" aria-hidden="false" aria-label="Example home icon">home
-            </mat-icon>
+            <mat-icon class="homeFullScreenIcon" aria-hidden="false" aria-label="Example home icon">home</mat-icon>
             CyAN FIELD
-          </div>
+		</button>
         </div>
       </div>
       <div>
         <div class="flex-child flex-container">
           <div [hidden]="windowWidthResize">
-            <div id='homeBtnSmID' class="homeBtnColor smNavBtn marginLeftSmallWidth" (click)="clickHome()"
+            <button id='homeBtnSmID' class="homeBtnColor smNavBtn marginLeftSmallWidth wm-focus" (click)="clickHome()"
               matTooltip="Home"
               aria-label="This is a yellow button featuring a house icon. Clicking on it will take you to the CyAN landing page.">
               <p>
                 <mat-icon aria-hidden="false" class="smBtnIcon" aria-label="Example home icon">home
                 </mat-icon>
               </p>
-            </div>
+            </button>
           </div>
           <div>
-            <div id='mapBtnID' class="mapBtnColor smNavBtn" (click)="clickMap()" matTooltip="Map"
+            <button id='mapBtnID' class="mapBtnColor smNavBtn wm-focus" (click)="clickMap()" matTooltip="Map"
               aria-label="This is a gray button featuring a map icon> Clicking on this button will lead to the the map and map filters.">
               <mat-icon class="smBtnIcon">map</mat-icon>
-            </div>
+			</button>
           </div>
           <div>
-            <div id='graphBtnID' class="graphBtnColor smNavBtn" (click)="clickGraph()" matTooltip="Graph"
+            <button id='graphBtnID' class="graphBtnColor smNavBtn wm-focus" (click)="clickGraph()" matTooltip="Graph"
               aria-label="This is a blue button featuring three dots meant to represent a graph. Clicking on this button will lead to the graph and graph filters.">
               <mat-icon class="smBtnIcon">scatter_plot</mat-icon>
-            </div>
+		    </button>
           </div>
           <div>
-            <div id='infoBtnID' class="infoBtnColor smNavBtn" (click)="clickInfo()" matTooltip="About"
+            <button id='infoBtnID' class="infoBtnColor smNavBtn wm-focus" (click)="clickInfo()" matTooltip="About"
               aria-label="This is an orange button feature a white icon logo (letter i with a circle around it). Clicking on this button will lead ot the info page.">
               <mat-icon class="smBtnIcon">info</mat-icon>
-            </div>
+		    </button>
           </div>
         </div>
       </div>

--- a/src/app/core/map-options/map-options.component.html
+++ b/src/app/core/map-options/map-options.component.html
@@ -14,10 +14,11 @@
   <div class="mapLayers leftBreak" id="mapLayersID">
     <label class="radioContainer" id="radioContainerResize0"
       aria-label="This button changes the base map to display streets">Streets & Cities
-      <input id="streetRadio" (change)="newBasemap()" type="radio" checked="checked" name="radio" />
+      <input id="streetRadio" (change)="newBasemap()" type="radio" checked="checked" name="radio"  />
       <span class="radioCheckmark" id="radioCheckmarkOuter0"></span>
     </label>
     <label class="radioContainer" id="radioContainerResize1"
+		for="imageryRadio"
       aria-label="This button changes the basemap to display satellite imagery">Satellite Imagery
       <input type="radio" name="radio" id="imageryRadio" (change)="newBasemap()" />
       <span class="radioCheckmark" id="radioCheckmarkOuter1"></span>

--- a/src/app/core/map-options/map-options.component.scss
+++ b/src/app/core/map-options/map-options.component.scss
@@ -1,3 +1,3 @@
 .floating-body {
-  pointer-events: all !important;
+	pointer-events: all !important;
 }

--- a/src/app/core/map/map.component.scss
+++ b/src/app/core/map/map.component.scss
@@ -37,7 +37,7 @@
   bottom: 60px !important;
   color: black;
   background-color: #ffffff;
-  background-color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 255, 255, 0.725);
   width: 80px;
   font-weight: 500;
   font-size: 11px;
@@ -80,7 +80,7 @@
 .custom .leaflet-popup-tip,
 .custom .leaflet-popup-content-wrapper {
   background: #8a8a8a;
-  color: #000000;
+  color: #0a0a0a;
 }
 
 .wimLogo {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -265,11 +265,9 @@ a.modebar-btn svg {
 }
 .mapFilterBtn {
   width: 100px;
-  line-height: 35px;
 }
 .flagTemplateBtn {
   width: 130px;
-  line-height: 35px;
 }
 .dataBtn {
   font-size: 16px;
@@ -489,14 +487,16 @@ mat-chip {
 }
 .aboutBtn {
   cursor: pointer;
-  height: 40px;
-  width: 40px;
+  height: 44px;
+  width: 44px;
   margin-right: 5px;
   text-align: center;
 }
 .aboutIcon {
-  margin-left: -4px;
-  margin-top: 3px;
+	font-size: 24px;
+	margin-top: 5px;
+	text-align: center;
+	display: block;
 }
 .version {
   text-align: right;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -92,8 +92,8 @@ a.modebar-btn svg {
 
 /* Start full home screen nav buttons */
 .homeBtn {
-  height: 60px;
-  width: 265px;
+  height: 70px;
+  width: 273px;
   font-size: 30px;
   vertical-align: middle;
 }
@@ -188,8 +188,8 @@ a.modebar-btn svg {
 	margin-top: 4px;
 }
 .smNavBtn {
-  height: 60px;
-  width: 60px;
+  height: 70px;
+  width: 70px;
   cursor: pointer;
   position: relative;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -96,7 +96,6 @@ a.modebar-btn svg {
   width: 265px;
   font-size: 30px;
   vertical-align: middle;
-  line-height: 60px;
 }
 .infoBtn {
   height: 210px;
@@ -119,7 +118,6 @@ a.modebar-btn svg {
 }
 .landingPgBtns {
   cursor: pointer;
-  position: relative;
   text-align: center;
 }
 .homeFullScreenIcon {
@@ -180,12 +178,14 @@ a.modebar-btn svg {
 
 /* Start small navbar buttons */
 .smBtnIcon {
-  font-size: 40px;
-  text-align: center;
-  line-height: 60px;
-  vertical-align: center;
-  margin-left: 10px;
-  position: relative;
+//   font-size: 40px;
+//   text-align: center;
+//   line-height: 60px;
+//   vertical-align: center;
+//   margin-left: 10px;
+//   position: relative;
+	transform: scale(1.5);
+	margin-top: 4px;
 }
 .smNavBtn {
   height: 60px;
@@ -542,6 +542,10 @@ mat-chip {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+
+  &:focus-within{
+	text-decoration: underline;
+  }
 }
 
 /* Hide the browser's default radio button */
@@ -755,4 +759,15 @@ h2,
   &.centered {
     justify-content: center;
   }
+}
+
+// Block display
+.block{
+	display: block;
+}
+.wm-focus{
+
+	&:focus{
+		text-decoration: underline;
+	}
 }


### PR DESCRIPTION
@kathymd - Resized the buttons a bit so they line up closer to what they were like before. The problem was changing them to actual <button> elements added some default browser styling that changed sizing and spacing.

I also adjusted the tab/keyboard control a bit. It now _should_ - even immediately after a refresh - tab through the top USGS nav first, then the main menu and content, thento the leaflet and WIM links on the map, then the footer.